### PR TITLE
Create dataView if not exist during fetching 

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_data_view_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_data_view_logic.test.ts
@@ -22,6 +22,7 @@ jest.mock('../../../shared/kibana/kibana_logic', () => ({
       data: {
         dataViews: {
           find: jest.fn(() => Promise.resolve([{ id: 'some-data-view-id' }])),
+          createAndSave: jest.fn(() => Promise.resolve([{ id: 'some-data-view-id' }])),
         },
       },
     },
@@ -57,6 +58,18 @@ describe('AnalyticsCollectionDataViewLogic', () => {
     it('should find and set dataView when analytics collection fetched', async () => {
       const dataView = { id: 'test' } as DataView;
       jest.spyOn(KibanaLogic.values.data.dataViews, 'find').mockResolvedValue([dataView]);
+
+      await FetchAnalyticsCollectionLogic.actions.apiSuccess({
+        events_datastream: 'events1',
+        name: 'collection1',
+      } as AnalyticsCollection);
+
+      expect(AnalyticsCollectionDataViewLogic.values.dataView).toEqual(dataView);
+    });
+
+    it('should create, save and set dataView when analytics collection fetched but dataView is not found', async () => {
+      const dataView = { id: 'test' } as DataView;
+      jest.spyOn(KibanaLogic.values.data.dataViews, 'createAndSave').mockResolvedValue(dataView);
 
       await FetchAnalyticsCollectionLogic.actions.apiSuccess({
         events_datastream: 'events1',

--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_data_view_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_data_view_logic.ts
@@ -29,13 +29,23 @@ export const AnalyticsCollectionDataViewLogic = kea<
   },
   listeners: ({ actions }) => ({
     [FetchAnalyticsCollectionLogic.actionTypes.apiSuccess]: async (collection) => {
-      const dataView = (
+      let dataView = (
         await KibanaLogic.values.data.dataViews.find(collection.events_datastream, 1)
       )?.[0];
 
-      if (dataView) {
-        actions.setDataView(dataView);
+      if (!dataView) {
+        dataView = await KibanaLogic.values.data.dataViews.createAndSave(
+          {
+            allowNoIndex: true,
+            name: `behavioral_analytics.events-${collection.name}`,
+            timeFieldName: '@timestamp',
+            title: collection.events_datastream,
+          },
+          true
+        );
       }
+
+      actions.setDataView(dataView);
     },
   }),
   path: ['enterprise_search', 'analytics', 'collections', 'dataView'],


### PR DESCRIPTION
## https://github.com/elastic/enterprise-search-team/issues/4271
### Description
In order to prevent the situation when the user creates a collection manually, but `dataView` is not created, it's required to create a `dataView` if it's not presented while fetching.

This PR is dedicated to introducing `dataView` creation and saving if it's not present