### PR TITLE
gate ai playground with ff

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.tsx
@@ -75,6 +75,9 @@ export const EnterpriseSearchContent: React.FC<InitialAppData> = (props) => {
 };
 
 export const EnterpriseSearchContentConfigured: React.FC<Required<InitialAppData>> = () => {
+  const {
+    productFeatures: { showAIPlayground },
+  } = useValues(KibanaLogic);
   return (
     <Routes>
       <Redirect exact from={ROOT_PATH} to={SEARCH_INDICES_PATH} />
@@ -93,9 +96,13 @@ export const EnterpriseSearchContentConfigured: React.FC<Required<InitialAppData
       <Route path={SETTINGS_PATH}>
         <Settings />
       </Route>
-      <Route path={AI_PLAYGROUND_PATH}>
-        <AIPlayground />
-      </Route>
+      {showAIPlayground ? (
+        <Route path={AI_PLAYGROUND_PATH}>
+          <AIPlayground />
+        </Route>
+      ) : (
+        <></>
+      )}
       <Route>
         <NotFound />
       </Route>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
@@ -109,17 +109,21 @@ export const useEnterpriseSearchNav = () => {
               },
             ]
           : []),
-        {
-          id: 'ai-playground',
-          name: i18n.translate('xpack.enterpriseSearch.nav.aiPlaygroundTitle', {
-            defaultMessage: 'AI Playground',
-          }),
-          ...generateNavLink({
-            shouldNotCreateHref: true,
-            shouldShowActiveForSubroutes: true,
-            to: ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + AI_PLAYGROUND_PATH,
-          }),
-        },
+        ...(productFeatures.showAIPlayground
+          ? [
+              {
+                id: 'ai-playground',
+                name: i18n.translate('xpack.enterpriseSearch.nav.aiPlaygroundTitle', {
+                  defaultMessage: 'AI Playground',
+                }),
+                ...generateNavLink({
+                  shouldNotCreateHref: true,
+                  shouldShowActiveForSubroutes: true,
+                  to: ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + AI_PLAYGROUND_PATH,
+                }),
+              },
+            ]
+          : []),
       ],
       name: i18n.translate('xpack.enterpriseSearch.nav.contentTitle', {
         defaultMessage: 'Content',

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/ai_playground.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/ai_playground.ts
@@ -1,12 +1,22 @@
-import { RouteDependencies } from '../../plugin';
-import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
-import Assist, { ConversationalChain } from '@elastic/ai-assist';
-import { ChatOpenAI } from '@elastic/ai-assist/models';
-import { Prompt } from '@elastic/ai-assist';
-import { schema } from '@kbn/config-schema';
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
 import Stream from 'stream';
 
-export function registerAIPlaygroundRoutes({ log, router }: RouteDependencies) {
+import Assist, { ConversationalChain, Prompt } from '@elastic/ai-assist';
+import { ChatOpenAI } from '@elastic/ai-assist/models';
+import { schema } from '@kbn/config-schema';
+
+import { RouteDependencies } from '../../plugin';
+import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
+
+export function registerAIPlaygroundRoutes({ log, router, config }: RouteDependencies) {
+  if (!config.showAIPlayground) return;
+
   router.post(
     {
       path: '/internal/enterprise_search/ai_playground/chat',


### PR DESCRIPTION
## Summary

Use the config feature flag to enable AI Playground, with this PR you will need to update your `kibana.dev.yml` to include

```yaml
enterpriseSearch.showAIPlayground: true
```