### PR TITLE
Adding restriciton on AI Playground

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.tsx
@@ -75,6 +75,9 @@ export const EnterpriseSearchContent: React.FC<InitialAppData> = (props) => {
 };
 
 export const EnterpriseSearchContentConfigured: React.FC<Required<InitialAppData>> = () => {
+  const {
+    productFeatures: { showAIPlayground },
+  } = useValues(KibanaLogic);
   return (
     <Routes>
       <Redirect exact from={ROOT_PATH} to={SEARCH_INDICES_PATH} />
@@ -93,9 +96,11 @@ export const EnterpriseSearchContentConfigured: React.FC<Required<InitialAppData
       <Route path={SETTINGS_PATH}>
         <Settings />
       </Route>
-      <Route path={AI_PLAYGROUND_PATH}>
-        <AIPlayground />
-      </Route>
+      {showAIPlayground && (
+        <Route path={AI_PLAYGROUND_PATH}>
+          <AIPlayground />
+        </Route>
+      )}
       <Route>
         <NotFound />
       </Route>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
@@ -109,17 +109,21 @@ export const useEnterpriseSearchNav = () => {
               },
             ]
           : []),
-        {
-          id: 'ai-playground',
-          name: i18n.translate('xpack.enterpriseSearch.nav.aiPlaygroundTitle', {
-            defaultMessage: 'AI Playground',
-          }),
-          ...generateNavLink({
-            shouldNotCreateHref: true,
-            shouldShowActiveForSubroutes: true,
-            to: ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + AI_PLAYGROUND_PATH,
-          }),
-        },
+        ...(productFeatures.showAIPlayground
+          ? [
+              {
+                id: 'ai-playground',
+                name: i18n.translate('xpack.enterpriseSearch.nav.aiPlaygroundTitle', {
+                  defaultMessage: 'AI Playground',
+                }),
+                ...generateNavLink({
+                  shouldNotCreateHref: true,
+                  shouldShowActiveForSubroutes: true,
+                  to: ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + AI_PLAYGROUND_PATH,
+                }),
+              },
+            ]
+          : []),
       ],
       name: i18n.translate('xpack.enterpriseSearch.nav.contentTitle', {
         defaultMessage: 'Content',

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/ai_playground.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/ai_playground.ts
@@ -15,9 +15,12 @@ import { streamFactory } from '@kbn/ml-response-stream/server';
 
 import { RouteDependencies } from '../../plugin';
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
-import { createApiKey } from '@kbn/enterprise-search-plugin/server/lib/analytics/create_api_key';
 
-export function registerAIPlaygroundRoutes({ log, router }: RouteDependencies) {
+export function registerAIPlaygroundRoutes({ log, router, config }: RouteDependencies) {
+  if (!config.showAIPlayground) {
+    return;
+  }
+
   router.post(
     {
       path: '/internal/enterprise_search/ai_playground/query_source_fields',


### PR DESCRIPTION
## Summary

Inspired by https://github.com/yansavitski/kibana/pull/11. Tested by running tests and played with configuration too.

Add this config in `kibana.dev.yml` and make sure both enterprise search and ES is running.
enterpriseSearch.showAIPlayground: true


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
